### PR TITLE
Add xUnit tests for RelayCommand

### DIFF
--- a/GitDashDemo.Tests/Commands/RelayCommandTests.cs
+++ b/GitDashDemo.Tests/Commands/RelayCommandTests.cs
@@ -1,0 +1,55 @@
+using GitDashDemo;
+using Xunit;
+
+namespace GitDashDemo.Tests.Commands
+{
+    public class RelayCommandTests
+    {
+        [Fact]
+        public void Execute_CallsProvidedAction()
+        {
+            bool executed = false;
+            var command = new RelayCommand(() => executed = true);
+
+            command.Execute(null);
+
+            Assert.True(executed);
+        }
+
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void CanExecute_ReturnsDelegateResult(bool expected)
+        {
+            var command = new RelayCommand(() => { }, () => expected);
+
+            bool result = command.CanExecute(null);
+
+            Assert.Equal(expected, result);
+        }
+
+        [Fact]
+        public void Execute_WithParameterAction_ReceivesParameter()
+        {
+            object? received = null;
+            var param = new object();
+            var command = new RelayCommand(p => received = p);
+
+            command.Execute(param);
+
+            Assert.Same(param, received);
+        }
+
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void CanExecute_WithParameter_ReturnsDelegateResult(bool expected)
+        {
+            var command = new RelayCommand(_ => { }, _ => expected);
+
+            bool result = command.CanExecute(new object());
+
+            Assert.Equal(expected, result);
+        }
+    }
+}

--- a/GitDashDemo.Tests/GitDashDemo.Tests.csproj
+++ b/GitDashDemo.Tests/GitDashDemo.Tests.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+    <PackageReference Include="xunit" Version="2.5.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.0" />
+    <PackageReference Include="coverlet.collector" Version="3.2.0" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\GitDashDemo\GitDashDemo.csproj" />
+  </ItemGroup>
+</Project>

--- a/GitDashDemo.sln
+++ b/GitDashDemo.sln
@@ -5,6 +5,8 @@ VisualStudioVersion = 17.8.34408.163
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "GitDashDemo", "GitDashDemo\GitDashDemo.csproj", "{ACE30BBC-12F5-4817-AB31-16BFB025F859}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "GitDashDemo.Tests", "GitDashDemo.Tests\GitDashDemo.Tests.csproj", "{514AFD91-528C-406D-B50D-AB2A76E3455A}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -14,8 +16,12 @@ Global
 		{ACE30BBC-12F5-4817-AB31-16BFB025F859}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{ACE30BBC-12F5-4817-AB31-16BFB025F859}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{ACE30BBC-12F5-4817-AB31-16BFB025F859}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{ACE30BBC-12F5-4817-AB31-16BFB025F859}.Release|Any CPU.Build.0 = Release|Any CPU
-	EndGlobalSection
+                {ACE30BBC-12F5-4817-AB31-16BFB025F859}.Release|Any CPU.Build.0 = Release|Any CPU
+                {514AFD91-528C-406D-B50D-AB2A76E3455A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+                {514AFD91-528C-406D-B50D-AB2A76E3455A}.Debug|Any CPU.Build.0 = Debug|Any CPU
+                {514AFD91-528C-406D-B50D-AB2A76E3455A}.Release|Any CPU.ActiveCfg = Release|Any CPU
+                {514AFD91-528C-406D-B50D-AB2A76E3455A}.Release|Any CPU.Build.0 = Release|Any CPU
+        EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
 	EndGlobalSection


### PR DESCRIPTION
## Summary
- create **GitDashDemo.Tests** xUnit project
- verify `RelayCommand` action execution and `CanExecute` behavior
- include new test project in the solution file

## Testing
- `dotnet test GitDashDemo.sln --no-build` *(fails: `dotnet` not found)*

